### PR TITLE
Correct Zanza png string in data file

### DIFF
--- a/src/js/data/2021-04-05.js
+++ b/src/js/data/2021-04-05.js
@@ -1012,7 +1012,7 @@ dataSet[dataSetVersion].characterData = [
   },
   {
     name: "Zanza",
-    img: "TGC-Zanza.png",
+    img: "XC-Zanza.png",
     opts: {
       role: ["nonplayable", "antagonist"],
       series: ["XC"],


### PR DESCRIPTION
@ReinaSakuraba was noticing that i was stuck in eternal load when clicking spoiler off on main page, found that was getting a 404 for zanza's png alone. his png string had been set to "TCG-Zanza" which does not exist. change is reverting string to "XC-Zanza", the correct string for the image 